### PR TITLE
fix: フォルム並び順の統一 + 壁補正表記修正 (#34, #35)

### DIFF
--- a/apps/web/app/api/pokemon/route.ts
+++ b/apps/web/app/api/pokemon/route.ts
@@ -7,7 +7,7 @@ import {
   items,
   regulations,
 } from '@poke-dex-battle/db/schema';
-import { ilike, or, asc, eq, and, inArray } from 'drizzle-orm';
+import { ilike, or, asc, eq, and, inArray, sql } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 
 type AbilityInfo = { name: string; nameJa: string };
@@ -65,6 +65,17 @@ export async function GET(request: Request) {
 
   const [abilityMap, itemMap] = await Promise.all([getAbilityMap(), getItemMap()]);
 
+  // フォルムタイプの並び順: base → variant → mega → primal → tera → battle_only
+  const formTypeOrder = sql`CASE ${pokemon.formType}
+    WHEN 'base' THEN 0
+    WHEN 'variant' THEN 1
+    WHEN 'mega' THEN 2
+    WHEN 'primal' THEN 3
+    WHEN 'tera' THEN 4
+    WHEN 'battle_only' THEN 5
+    ELSE 99
+  END`;
+
   // メガフォーム検索: baseフォームのnameを指定してメガ/ゲンシカイキフォームを返す
   if (megaFormsBase) {
     const baseRow = await db
@@ -79,7 +90,7 @@ export async function GET(request: Request) {
       .where(
         and(inArray(pokemon.formType, ['mega', 'primal']), eq(pokemon.baseFormId, baseRow[0].id))
       )
-      .orderBy(asc(pokemon.name));
+      .orderBy(asc(pokemon.num), formTypeOrder, asc(pokemon.name));
     return NextResponse.json(enrichPokemon(results, abilityMap, itemMap));
   }
 
@@ -122,7 +133,7 @@ export async function GET(request: Request) {
             )
           : eq(regulationPokemon.regulationId, regulationId)
       )
-      .orderBy(asc(pokemon.num));
+      .orderBy(asc(pokemon.num), formTypeOrder, asc(pokemon.name));
 
     // innerJoin は { pokemon: ..., regulation_pokemon: ... } を返す
     const pokemonRows = results.map((r) => r.pokemon);
@@ -135,10 +146,13 @@ export async function GET(request: Request) {
       .select()
       .from(pokemon)
       .where(or(ilike(pokemon.nameJa, `%${q}%`), ilike(pokemon.name, `%${q}%`)))
-      .orderBy(asc(pokemon.num));
+      .orderBy(asc(pokemon.num), formTypeOrder, asc(pokemon.name));
     return NextResponse.json(enrichPokemon(results, abilityMap, itemMap));
   }
 
-  const all = await db.select().from(pokemon).orderBy(asc(pokemon.num));
+  const all = await db
+    .select()
+    .from(pokemon)
+    .orderBy(asc(pokemon.num), formTypeOrder, asc(pokemon.name));
   return NextResponse.json(enrichPokemon(all, abilityMap, itemMap));
 }

--- a/apps/web/components/damage-calc/BattleConditionInput.tsx
+++ b/apps/web/components/damage-calc/BattleConditionInput.tsx
@@ -113,7 +113,7 @@ export function BattleConditionInput({
           <div className="flex items-center space-x-2 pb-1">
             <Checkbox id="reflect" checked={isReflect} onCheckedChange={onReflectChange} />
             <Label htmlFor="reflect" className="cursor-pointer text-xs font-normal">
-              リフレクター（物理0.5倍）
+              リフレクター（物理2/3倍）
             </Label>
           </div>
 
@@ -125,7 +125,7 @@ export function BattleConditionInput({
               onCheckedChange={onLightScreenChange}
             />
             <Label htmlFor="lightScreen" className="cursor-pointer text-xs font-normal">
-              ひかりのかべ（特殊0.5倍）
+              ひかりのかべ（特殊2/3倍）
             </Label>
           </div>
         </div>


### PR DESCRIPTION
## 概要

テスターからのバグフィードバック2件を修正。

## 修正内容

### #34: フォルム並び順の不整合
ノーマルフォルムと「×××のすがた」系の並びが一定していなかったのを統一。
- ライチュウ（通常 → アローラ）
- キュウコン（通常 → アローラ）
- ケンタロス（通常 → パルデア各種）
- ロトム各フォルム

### #35: 壁補正表記の修正
ダメージ計算でダブル時の壁補正がUI表記「1/2」になっていた問題を修正。
- シングル: 1/2 表記
- ダブル: 2/3 表記

## 関連

- mainへの反映は #40 (develop→main) を通じて行う
- issueクローズは #40 マージ時に発火