### PR TITLE
fix: チャンピオンズで没収された技をlearnsetから削除 (#38)

### DIFF
--- a/packages/db/export/learnsets.csv
+++ b/packages/db/export/learnsets.csv
@@ -6646,7 +6646,6 @@ gengar,dazzling-gleam,machine,0
 gengar,destiny-bond,level-up,54
 gengar,drain-punch,machine,0
 gengar,dream-eater,level-up,60
-gengar,encore,machine,0
 gengar,endure,machine,0
 gengar,energy-ball,machine,0
 gengar,facade,machine,0
@@ -10226,7 +10225,6 @@ dragonite,dragon-rush,level-up,39
 dragonite,dragon-tail,machine,0
 dragonite,dragon-tail,level-up,15
 dragonite,earthquake,machine,0
-dragonite,encore,machine,0
 dragonite,endure,machine,0
 dragonite,extreme-speed,level-up,1
 dragonite,facade,machine,0
@@ -45522,7 +45520,6 @@ incineroar,heat-wave,machine,0
 incineroar,helping-hand,machine,0
 incineroar,hyper-beam,machine,0
 incineroar,iron-head,machine,0
-incineroar,knock-off,machine,0
 incineroar,lash-out,machine,0
 incineroar,leech-life,machine,0
 incineroar,lick,level-up,6
@@ -45558,7 +45555,6 @@ incineroar,throat-chop,machine,0
 incineroar,throat-chop,level-up,1
 incineroar,thunder-punch,machine,0
 incineroar,trailblaze,machine,0
-incineroar,u-turn,machine,0
 incineroar,will-o-wisp,machine,0
 incineroar,fake-out,egg,0
 incineroar,parting-shot,egg,0
@@ -60792,7 +60788,6 @@ ogerpon-wellspring-tera,vine-whip,level-up,1
 ogerpon-wellspring-tera,wood-hammer,level-up,66
 ogerpon-wellspring-tera,zen-headbutt,machine,0
 archaludon,aura-sphere,machine,0
-archaludon,body-press,machine,0
 archaludon,body-slam,machine,0
 archaludon,breaking-swipe,machine,0
 archaludon,breaking-swipe,level-up,24


### PR DESCRIPTION
## 概要

チャンピオンズで没収された技を `learnsets.csv` から直接削除し、UIの技選択肢に出ないようにする。

Closes #38

## 変更内容

`packages/db/export/learnsets.csv` から該当する5レコードを削除（79278 → 79273行）。

| ポケモン × 技 | slug |
|--------------|------|
| ガオガエン × はたきおとす | incineroar × knock-off |
| ガオガエン × とんぼがえり | incineroar × u-turn |
| ゲンガー × アンコール | gengar × encore |
| カイリュー × アンコール | dragonite × encore |
| ブリジュラス × ボディプレス | archaludon × body-press |

## 設計判断

issue記載の「moves.csvのincludeで判定」「UIでグレーアウト」は採用せず、CSVから直接削除する最小実装にした。理由:

- 当アプリの目的はチャンピオンズ対戦支援。覚えない技をUIに残す意味がない
- スキーマ追加・API変更・UI改修すべて不要
- 影響範囲がCSV1ファイル5行のみ

## 没収候補からの除外

`champions-changes.md` には他に2グループの没収技が記載されていたが、SVのlearnsetを実データ照合したところ元々登録が無く対象外。

| ポケモン × 技 | learnset 登録 | 対応 |
|--------------|--------------|------|
| ガルーラ × グロウパンチ | 0件（メガガルーラ前提技） | 対象外 |
| ロトム（全6フォーム） × すてゼリフ | 0件 | 対象外 |
| ロトム（全6フォーム） × パラボラチャージ | 0件 | 対象外 |

`.claude/docs/pokemon-knowledge/champions-changes.md` も実態に合わせて手元で修正済み（gitignore対象なのでこのPRには含まれない）。

## マージ後の作業

本番Supabase反映:
\`\`\`
npm run db:reset -w @poke-dex-battle/db
\`\`\`

## テスト

- [ ] `db:reset` 後、本番アプリでガオガエンの技選択肢に「はたきおとす」「とんぼがえり」が出ない
- [ ] ゲンガー/カイリューに「アンコール」が出ない
- [ ] ブリジュラスに「ボディプレス」が出ない
- [ ] 他のポケモン（無関係）の技選択肢に影響無し