### PR TITLE
develop → main: チャンピオンズ没収技をlearnsetから削除 (#38)

### DIFF
--- a/packages/db/export/learnsets.csv
+++ b/packages/db/export/learnsets.csv
@@ -6646,7 +6646,6 @@ gengar,dazzling-gleam,machine,0
 gengar,destiny-bond,level-up,54
 gengar,drain-punch,machine,0
 gengar,dream-eater,level-up,60
-gengar,encore,machine,0
 gengar,endure,machine,0
 gengar,energy-ball,machine,0
 gengar,facade,machine,0
@@ -10226,7 +10225,6 @@ dragonite,dragon-rush,level-up,39
 dragonite,dragon-tail,machine,0
 dragonite,dragon-tail,level-up,15
 dragonite,earthquake,machine,0
-dragonite,encore,machine,0
 dragonite,endure,machine,0
 dragonite,extreme-speed,level-up,1
 dragonite,facade,machine,0
@@ -45522,7 +45520,6 @@ incineroar,heat-wave,machine,0
 incineroar,helping-hand,machine,0
 incineroar,hyper-beam,machine,0
 incineroar,iron-head,machine,0
-incineroar,knock-off,machine,0
 incineroar,lash-out,machine,0
 incineroar,leech-life,machine,0
 incineroar,lick,level-up,6
@@ -45558,7 +45555,6 @@ incineroar,throat-chop,machine,0
 incineroar,throat-chop,level-up,1
 incineroar,thunder-punch,machine,0
 incineroar,trailblaze,machine,0
-incineroar,u-turn,machine,0
 incineroar,will-o-wisp,machine,0
 incineroar,fake-out,egg,0
 incineroar,parting-shot,egg,0
@@ -60792,7 +60788,6 @@ ogerpon-wellspring-tera,vine-whip,level-up,1
 ogerpon-wellspring-tera,wood-hammer,level-up,66
 ogerpon-wellspring-tera,zen-headbutt,machine,0
 archaludon,aura-sphere,machine,0
-archaludon,body-press,machine,0
 archaludon,body-slam,machine,0
 archaludon,breaking-swipe,machine,0
 archaludon,breaking-swipe,level-up,24


### PR DESCRIPTION
## 概要

PR #43 の develop マージ分を main へ反映するリリースPR。

## 主要変更

- fix: チャンピオンズで没収された技をlearnsetから削除 (#38, PR #43)
  - ガオガエン × はたきおとす、とんぼがえり
  - ゲンガー × アンコール
  - カイリュー × アンコール
  - ブリジュラス × ボディプレス

## マージ後の作業

本番Supabaseに反映:
\`\`\`
npm run db:reset -w @poke-dex-battle/db
\`\`\`

## クローズされるIssue

Closes #38

## マージ方式

Create a merge commit（リリースPRなのでsquashではなくmerge）